### PR TITLE
Add the line number in the assert message

### DIFF
--- a/tests/org.eclipse.epsilon.eol.staticanalyser.tests/src/org/eclipse/epsilon/eol/staticanalyser/tests/AbstractStaticAnalysisTest.java
+++ b/tests/org.eclipse.epsilon.eol.staticanalyser.tests/src/org/eclipse/epsilon/eol/staticanalyser/tests/AbstractStaticAnalysisTest.java
@@ -313,7 +313,8 @@ public abstract class AbstractStaticAnalysisTest extends AbstractBaseTest {
 			// Multiline comments (/* */") are used to capture the expected type of
 			// expressions
 			if (!element.getComments().isEmpty() && element.getComments().get(0).isMultiline()) {
-				assertEquals(element.getComments().get(0).toString(), getResolvedType(element).toString());
+				assertEquals("Starting line " + element.getRegion().getStart().getLine(),
+						element.getComments().get(0).toString(), getResolvedType(element).toString());
 			}
 			visit(element.getChildren());
 		}


### PR DESCRIPTION
Simple update to add the line number to the assert test message. This reports the test line that the expected return type didn't match.