### PR TITLE
Collect comment/element type mismatches to a list, empty list passes

### DIFF
--- a/tests/org.eclipse.epsilon.eol.staticanalyser.tests/src/org/eclipse/epsilon/eol/staticanalyser/tests/AbstractStaticAnalysisTest.java
+++ b/tests/org.eclipse.epsilon.eol.staticanalyser.tests/src/org/eclipse/epsilon/eol/staticanalyser/tests/AbstractStaticAnalysisTest.java
@@ -224,11 +224,11 @@ public abstract class AbstractStaticAnalysisTest extends AbstractBaseTest {
 	}
 	
 	private String formatTypeResults(List<String> results) {
-		String niceResults = "";
-		for (String r : results) {
-			niceResults = niceResults.concat("- " + r + "\n");
-		}
-		return niceResults;
+		StringBuilder sb = new StringBuilder();
+	    for (String r : results) {
+	        sb.append("- ").append(r).append("\n");
+	    }
+	    return sb.toString();
 	}
 	
 	protected List<String> visit(List<ModuleElement> elements) {


### PR DESCRIPTION
The test collects all the failures to a list, and reports the list upon failing test when list is not empty.

When the test fails, the reported errors with the type mismatches now include the element Classes simple name and column.

<img width="529" height="233" alt="image" src="https://github.com/user-attachments/assets/1c831b06-086d-415f-8101-d5c7dd215cc7" />
