### PR TITLE
58 add lines from test file to type check errors

### DIFF
--- a/tests/org.eclipse.epsilon.eol.staticanalyser.tests/src/org/eclipse/epsilon/eol/staticanalyser/tests/AbstractBaseTest.java
+++ b/tests/org.eclipse.epsilon.eol.staticanalyser.tests/src/org/eclipse/epsilon/eol/staticanalyser/tests/AbstractBaseTest.java
@@ -2,10 +2,12 @@ package org.eclipse.epsilon.eol.staticanalyser.tests;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
@@ -15,6 +17,7 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
+import org.eclipse.epsilon.common.parse.Region;
 
 public abstract class AbstractBaseTest {
 	
@@ -111,5 +114,24 @@ public abstract class AbstractBaseTest {
 		}
 
 	}
+	
+	protected String getLineFromProgramFile(int lineNumber) {
+		try (Stream<String> lines = Files.lines(programFile.toPath())) {
+			// skip is 0-indexed, so (lineNumber - 1) gets the correct line
+			return lines.skip(lineNumber - 1).findFirst().orElse("[Line " + lineNumber + " not found]");
+		} catch (Exception e) {
+			return "[Error reading file: " + e.getMessage() + "]";
+		}
+	}
+	
+	protected List<String> getRegionLinesFromFile(Region region) {
+		List<String> listFileLines = new ArrayList<String>();
+		for(int line = region.getStart().getLine(); line <= region.getEnd().getLine(); line++) {
+			listFileLines.add(getLineFromProgramFile(line));
+		}		
+		return listFileLines;
+		
+	}
+	
 
 }

--- a/tests/org.eclipse.epsilon.eol.staticanalyser.tests/src/org/eclipse/epsilon/eol/staticanalyser/tests/AbstractStaticAnalysisTest.java
+++ b/tests/org.eclipse.epsilon.eol.staticanalyser.tests/src/org/eclipse/epsilon/eol/staticanalyser/tests/AbstractStaticAnalysisTest.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 import org.eclipse.epsilon.common.module.ModuleElement;
 import org.eclipse.epsilon.common.module.ModuleMarker;
 import org.eclipse.epsilon.common.module.ModuleMarker.Severity;
+import org.eclipse.epsilon.common.parse.Region;
 import org.eclipse.epsilon.eol.EolModule;
 import org.eclipse.epsilon.eol.staticanalyser.EolStaticAnalyser;
 import org.eclipse.epsilon.eol.staticanalyser.types.EolType;
@@ -182,7 +183,7 @@ public abstract class AbstractStaticAnalysisTest extends AbstractBaseTest {
 			}
 		}
 		assertTrue("\nStatic Analysis Marker with MESSAGE not found for Test Marker " + testMarkerIndex + " :\n"
-				+ testMarker.toString(), candidatesByMessage.size() > 0);
+				+ testMarker.toString() + getFormattedProgramString(testMarker.getRegion()), candidatesByMessage.size() > 0);
 
 		List<ModuleMarker> candidatesByRegion = new ArrayList<ModuleMarker>();
 		for (ModuleMarker staticAnalysisMarker : candidatesByMessage) {
@@ -216,11 +217,12 @@ public abstract class AbstractStaticAnalysisTest extends AbstractBaseTest {
 	}
 	
 	public String asBulletListString (List<ModuleMarker> listOfModuleMarkers) {
-		String staticAnalyserMarkersString = "";
+		StringBuilder staticAnalyserMarkersString = new StringBuilder();
 		for (ModuleMarker staticAnalyserMarker : listOfModuleMarkers) {
-			staticAnalyserMarkersString = staticAnalyserMarkersString.concat(" - " + staticAnalyserMarker.toString() + "\n");
+			staticAnalyserMarkersString.append(" - " + staticAnalyserMarker.toString());
+			staticAnalyserMarkersString.append(getFormattedProgramString(staticAnalyserMarker.getRegion()) + "\n");
 		}
-		return staticAnalyserMarkersString;
+		return staticAnalyserMarkersString.toString();
 	}
 	
 	private String formatTypeResults(List<String> results) {
@@ -247,18 +249,32 @@ public abstract class AbstractStaticAnalysisTest extends AbstractBaseTest {
 				}
 
 				if (!commentTypeString.equals(elementTypeString)) {
+					String programString = getFormattedProgramString(element.getRegion());
 					results.add(String.format("Line: %s, element '%s' column %s to %s"
-							+ "\n \t  Expected: /*%s*/ \tWas: /*%s*/",
+							+ "\n \t  Expected: /*%s*/ \tWas: /*%s*/" 
+							+ "%s",
 							element.getRegion().getStart().getLine(),
 							element.getClass().getSimpleName(),
 							element.getRegion().getStart().getColumn(),
 							element.getRegion().getEnd().getColumn(),							
-							commentTypeString, elementTypeString));
+							commentTypeString, elementTypeString,
+							programString));
 				}
 			}
 			results.addAll(visit(element.getChildren()));
 		}
 		return results;
+	}
+
+	private String getFormattedProgramString(Region region) {
+		List<String> programLines = getRegionLinesFromFile(region);
+		StringBuilder programString = new StringBuilder();
+		int line = region.getStart().getLine();
+		for (String pLine : programLines) {
+			programString.append("\n \t \t line " + line + " -> " + pLine);
+			line++;
+		}
+		return programString.toString();
 	}
 
 	protected EolType getResolvedType(ModuleElement element) {


### PR DESCRIPTION
This PR add the lines of an eol program file to a unit test error message. The lines of the program for just the region relating to the error are reported.

Also includes a replacement of a string concatenation with StringBuilder for reporting error messages.